### PR TITLE
Add "random" mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To play, follow one of the installation guides below. After that, you can just n
 You might also want to `git pull` to ensure that your git history is up-to-date. Otherwise, you may end up playing the wrong game for the day. The program doesn't do this automatically because I didn't want it to make any changes to the file system.
 
 ### Installation from source (recommended)
-With any v1.21 or greater of [Golang](https://go.dev/) you can easily install from source:
+With any v1.22 or greater of [Golang](https://go.dev/) you can easily install from source:
 
 ```shell
 go install github.com/josephnaberhaus/gauthordle@latest

--- a/internal/game/authors.go
+++ b/internal/game/authors.go
@@ -2,11 +2,11 @@ package game
 
 import (
 	"fmt"
-	"github.com/josephnaberhaus/gauthordle/internal/git"
 	"math"
-	"math/rand"
 	"slices"
 	"strings"
+
+	"github.com/josephnaberhaus/gauthordle/internal/git"
 )
 
 func commitsByAuthorEmail(commits []git.Commit) map[string][]git.Commit {
@@ -50,7 +50,7 @@ func allAuthorEmails(commits []git.Commit) []string {
 	return result
 }
 
-func pickAuthor(commits []git.Commit, random *rand.Rand) (string, error) {
+func pickAuthor(commits []git.Commit, random func(int) int) (string, error) {
 	numByAuthor := numCommitsByAuthorEmail(commits)
 	allAuthors := allAuthorEmails(commits)
 
@@ -80,7 +80,7 @@ func pickAuthor(commits []git.Commit, random *rand.Rand) (string, error) {
 	// A higher bias increases the likelihood that a high-contributing user will be picked.
 	const biasPower = float64(3.5)
 	randMax := math.Pow(float64(len(allAuthors)), biasPower)
-	randNumber := random.Intn(int(math.Floor(randMax)))
+	randNumber := random(int(math.Floor(randMax)))
 	index := int(math.Pow(float64(randNumber), 1/biasPower))
 
 	// Make sure that floating point error didn't put us in an invalid index

--- a/internal/game/authors.go
+++ b/internal/game/authors.go
@@ -3,6 +3,7 @@ package game
 import (
 	"fmt"
 	"math"
+	"math/rand"
 	"slices"
 	"strings"
 
@@ -50,7 +51,7 @@ func allAuthorEmails(commits []git.Commit) []string {
 	return result
 }
 
-func pickAuthor(commits []git.Commit, random func(int) int) (string, error) {
+func pickAuthor(commits []git.Commit, random *rand.Rand) (string, error) {
 	numByAuthor := numCommitsByAuthorEmail(commits)
 	allAuthors := allAuthorEmails(commits)
 
@@ -80,7 +81,7 @@ func pickAuthor(commits []git.Commit, random func(int) int) (string, error) {
 	// A higher bias increases the likelihood that a high-contributing user will be picked.
 	const biasPower = float64(3.5)
 	randMax := math.Pow(float64(len(allAuthors)), biasPower)
-	randNumber := random(int(math.Floor(randMax)))
+	randNumber := random.Intn(int(math.Floor(randMax)))
 	index := int(math.Pow(float64(randNumber), 1/biasPower))
 
 	// Make sure that floating point error didn't put us in an invalid index

--- a/internal/game/builder.go
+++ b/internal/game/builder.go
@@ -2,25 +2,34 @@ package game
 
 import (
 	"fmt"
-	"github.com/josephnaberhaus/gauthordle/internal/git"
 	"math/rand"
 	"time"
+
+	"github.com/josephnaberhaus/gauthordle/internal/git"
 )
 
 // Increment to permanently change the RNG of the game.
 const seed = 0
 
+func BuildRandom() (Puzzle, error) {
+	return buildGame(rand.Intn)
+}
+
 func BuildToday() (Puzzle, error) {
-	startTime, endTime := puzzleTimeRange()
+	startTime, _ := puzzleTimeRange()
 	// Make a random based on the end time so that it's stable throughout the day.
 	random := rand.New(rand.NewSource(startTime.Unix() + seed))
+	return buildGame(random.Intn)
+}
 
+func buildGame(r func(int) int) (Puzzle, error) {
+	startTime, endTime := puzzleTimeRange()
 	commits, err := git.GetCommits(startTime, endTime)
 	if err != nil {
 		return Puzzle{}, fmt.Errorf("error building puzzle: %w", err)
 	}
 
-	author, err := pickAuthor(commits, random)
+	author, err := pickAuthor(commits, r)
 	if err != nil {
 		return Puzzle{}, fmt.Errorf("error building puzzle: %w", err)
 	}
@@ -37,7 +46,7 @@ func BuildToday() (Puzzle, error) {
 		authorEmail:   author,
 		authorName:    authorNames[author],
 		authorCommits: commitsByAuthor[author],
-		puzzleCommits: pickPuzzleCommits(commitsByAuthor[author], random),
+		puzzleCommits: pickPuzzleCommits(commitsByAuthor[author], r),
 		hints: puzzleHints{
 			totalCommits:    len(commitsByAuthor[author]),
 			mostTouchedFile: mostTouchedFile,
@@ -47,11 +56,11 @@ func BuildToday() (Puzzle, error) {
 	}, nil
 }
 
-func pickPuzzleCommits(authorCommits []git.Commit, random *rand.Rand) [numPuzzleCommits]git.Commit {
+func pickPuzzleCommits(authorCommits []git.Commit, random func(int) int) [numPuzzleCommits]git.Commit {
 	var result [numPuzzleCommits]git.Commit
 	pickedIndices := map[int]struct{}{}
 	for i := 0; i < numPuzzleCommits; i++ {
-		index := random.Intn(len(authorCommits))
+		index := random(len(authorCommits))
 		if _, ok := pickedIndices[index]; ok {
 			// We've already picked this number. Try again.
 			i--

--- a/main.go
+++ b/main.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
+	"os"
+
 	"github.com/josephnaberhaus/gauthordle/internal/game"
 	"github.com/josephnaberhaus/gauthordle/internal/git"
 	escapes "github.com/snugfox/ansi-escapes"
-	"os"
 )
 
 const help = "A daily game where you try to guess the author of some Git commits.\n\nTo play, simply \"git checkout\" the main development branch of your repository\nand run this program with no arguments.\n\nNew games start at midnight Central Time."
@@ -17,8 +19,14 @@ func exit(err error) {
 }
 
 func main() {
-	if len(os.Args) > 1 {
+	random := flag.Bool("random", false, "If true, play a random game instead of the daily game.")
+	flag.Parse()
+
+	if len(flag.Args()) > 0 {
 		fmt.Println(help)
+		fmt.Println()
+
+		flag.Usage()
 		os.Exit(0)
 	}
 
@@ -32,7 +40,13 @@ func main() {
 
 	fmt.Println("Building today's game...")
 
-	puzzle, err := game.BuildToday()
+	var puzzle game.Puzzle
+	var err error
+	if *random {
+		puzzle, err = game.BuildRandom()
+	} else {
+		puzzle, err = game.BuildToday()
+	}
 	if err != nil {
 		exit(err)
 	}


### PR DESCRIPTION
In addition to the daily game, some users are just begging for more ways to play. This PR adds a "random" mode that simply creates a random puzzle based on nothing (other than the seed of `math/rand`). Users can continually get new puzzles on-demand!