### PR TITLE
Allow filtering out users

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+type AuthorFilter struct {
+	// ExcludeName is a regular expression dictating which author names should be excluded.
+	ExcludeName string `yaml:"exclude_name"`
+
+	// ExcludeEmail is a regular expression dictating which author emails should be excluded.
+	ExcludeEmail string `yaml:"exclude_email"`
+}
+
+type Config struct {
+	AuthorFilters []AuthorFilter `yaml:"author_filters"`
+}
+
+func Load() (Config, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return Config{}, err
+	}
+
+	path := filepath.Join(home, ".gauthordle.yaml")
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// If the file simply doesn't exist, we provide an empty config.
+			return Config{}, nil
+		}
+		return Config{}, err
+	}
+	defer f.Close()
+
+	var cfg Config
+	err = yaml.NewDecoder(f).Decode(&cfg)
+	if err != nil {
+		return Config{}, err
+	}
+
+	return cfg, nil
+}

--- a/internal/git/commits_test.go
+++ b/internal/git/commits_test.go
@@ -1,8 +1,12 @@
 package git
 
 import (
-	"github.com/stretchr/testify/assert"
+	"slices"
 	"testing"
+
+	"github.com/josephnaberhaus/gauthordle/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFilterOutBots(t *testing.T) {
@@ -29,6 +33,92 @@ func TestFilterOutBots(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, filterOutBots(input))
+}
+
+func TestFilterForConfig(t *testing.T) {
+	input := []Commit{
+		{
+			AuthorName:  "Person 1",
+			AuthorEmail: "abc@abc.com",
+		},
+		{
+			AuthorName:  "Person 2",
+			AuthorEmail: "def@def.com",
+		},
+		{
+			AuthorName:  "Person 3",
+			AuthorEmail: "ghi@ghi.com",
+		},
+	}
+
+	tests := []struct {
+		desc string
+		cfg  config.Config
+		exp  []Commit
+	}{{
+		desc: "empty config should keep all",
+		cfg:  config.Config{},
+		exp:  input,
+	}, {
+		desc: "filter by name",
+		cfg: config.Config{
+			AuthorFilters: []config.AuthorFilter{{
+				ExcludeName: "2",
+			}},
+		},
+		exp: []Commit{input[0], input[2]},
+	}, {
+		desc: "filter by email",
+		cfg: config.Config{
+			AuthorFilters: []config.AuthorFilter{{
+				ExcludeEmail: "ghi",
+			}},
+		},
+		exp: []Commit{input[0], input[1]},
+	}, {
+		desc: "specify name and email, prefer name",
+		cfg: config.Config{
+			AuthorFilters: []config.AuthorFilter{{
+				ExcludeName:  "2",
+				ExcludeEmail: "ghi",
+			}},
+		},
+		exp: []Commit{input[0], input[2]},
+	}, {
+		desc: "specify multiple filters",
+		cfg: config.Config{
+			AuthorFilters: []config.AuthorFilter{{
+				ExcludeName: "2",
+			}, {
+				ExcludeEmail: "ghi",
+			}},
+		},
+		exp: []Commit{input[0]},
+	}, {
+		desc: "filter by name regexp",
+		cfg: config.Config{
+			AuthorFilters: []config.AuthorFilter{{
+				ExcludeName: "[2-3]",
+			}},
+		},
+		exp: []Commit{input[0]},
+	}, {
+		desc: "filter by email regexp",
+		cfg: config.Config{
+			AuthorFilters: []config.AuthorFilter{{
+				ExcludeEmail: "(abc|def)",
+			}},
+		},
+		exp: []Commit{input[2]},
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			commits, err := filterForConfig(slices.Clone(input), tc.cfg)
+			require.NoError(t, err)
+			assert.Equal(t, tc.exp, commits)
+		})
+	}
 }
 
 func TestConsolidateAuthorDetails(t *testing.T) {


### PR DESCRIPTION
Some repos have users that don't belong in the hardcoded filters here but that also shouldn't show up in a game. Allow specifying a config file (which lives at `~/.gauthordle.yaml`) to filter out users by email or name using regular expressions.