### PR TITLE
Run CI on PRs too

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,15 @@
 name: CI
 
 on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
   release:
     types:
       - created
-  push:
 
 jobs:
   release:


### PR DESCRIPTION
I couldn't get my CI workflows to run on #1 or #2. I think it's because I only specified to run CI on pushes.