### PR TITLE
Change how we filter for robots

### DIFF
--- a/internal/commit/commit.go
+++ b/internal/commit/commit.go
@@ -53,9 +53,8 @@ func (f *Filter) filterOutBots(commits []git.Commit) []git.Commit {
 			continue
 		}
 
-		// Often robots won't have a proper "<First> <Last>" name (with a space separator).
-		// This is going to have many false positives, but in the repos I tested it is more fun.
-		if !strings.Contains(commit.AuthorName, " ") {
+		// If the author's name contains the word "robot" that's a pretty good indication that it's a robot.
+		if strings.Contains(strings.ToLower(commit.AuthorName), "robot") {
 			continue
 		}
 

--- a/internal/commit/commit_test.go
+++ b/internal/commit/commit_test.go
@@ -19,7 +19,7 @@ func TestFilter_Filter_FilterOutBots(t *testing.T) {
 			AuthorEmail: "joe.smith@example.noreply.com",
 		},
 		{
-			AuthorName:  "NoSpace",
+			AuthorName:  "Robot",
 			AuthorEmail: "joe.smith@example.com",
 		},
 	}


### PR DESCRIPTION
The rule of filtering out names without spaces ended up filtering out some people I really didn't want to filter. Let's go without that.

Also, removing authors with the name "robot" in their name is a pretty simple win.