### PR TITLE
Small rendering improvements

### DIFF
--- a/internal/game/puzzle.go
+++ b/internal/game/puzzle.go
@@ -50,7 +50,7 @@ func (p Puzzle) Run() error {
 
 		output.PrintColor("Guess the author of the following commit", output.White)
 		if stage > 0 {
-			output.PrintColor("s", output.Yellow)
+			output.PrintColor("s", output.White)
 		}
 		output.PrintColorLn(":", output.Yellow)
 		output.Ln()

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 		exit(errors.New("must be in a git repository"))
 	}
 
-	fmt.Println("Building today's game...")
+	fmt.Println("Building game...")
 
 	startTime, endTime := game.PuzzleTimeRange()
 	cfg, err := config.Load()


### PR DESCRIPTION
Just fixing a couple of small things I noticed.

1. The "s" to make "commit" plural is yellow instead of white like the rest of the word
2. In `--random` mode it still says "Building todays game..." which is a little confusing. Just say "Building game..." instead.