### PR TITLE
Remove all commits with the word merge in them

### DIFF
--- a/internal/commit/commit.go
+++ b/internal/commit/commit.go
@@ -122,7 +122,7 @@ func (f *Filter) filterCommitSubjects(commits []git.Commit) []git.Commit {
 		}
 
 		// Merge commits aren't helpful
-		if strings.Contains(commit.SubjectLine, "Merge branch") {
+		if strings.Contains(strings.ToLower(commit.SubjectLine), "merge") {
 			continue
 		}
 

--- a/internal/commit/commit_test.go
+++ b/internal/commit/commit_test.go
@@ -250,6 +250,9 @@ func TestFilter_Filter_FiltersCommitSubjects(t *testing.T) {
 			SubjectLine: "Merge branch 'master' of...",
 		},
 		{
+			SubjectLine: "Merged master",
+		},
+		{
 			SubjectLine: "PREFIX Merge branch 'master' of...",
 		},
 	}

--- a/internal/commit/commit_test.go
+++ b/internal/commit/commit_test.go
@@ -250,7 +250,7 @@ func TestFilter_Filter_FiltersCommitSubjects(t *testing.T) {
 			SubjectLine: "Merge branch 'master' of...",
 		},
 		{
-			SubjectLine: "Merged master",
+			SubjectLine: "merged master",
 		},
 		{
 			SubjectLine: "PREFIX Merge branch 'master' of...",


### PR DESCRIPTION
Any commit with the word "merge" in it probably isn't very interesting or useful.